### PR TITLE
Converted static location engine to scheduled instead of at fixed rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /.idea/deploymentTargetSelector.xml
 /.idea/other.xml
 /.idea/material_theme_project_new.xml
+/.idea/ktfmt.xml
 .DS_Store
 /build
 /captures

--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ MapView(
 
 <img src="maplibre-compose-demo.gif" width="400" alt="Demo Animation"/>
 
+### Local development in an app
+
+Local development in your Android app projects is a bit tricky,
+but here's something that mostly works
+without thoroughly confusing yourself with Maven Local repos.
+(This is definitely a hack, but it works; suggestions welcome.)
+
+First, do a local release build.
+
+```shell
+./gradlew assembleRelease
+```
+
+Then, update your `build.gradle` to reference the locally built AAR
+(`api` works as well of course, if you had an API dependency):
+
+```groovy
+implementation files('/path/to/maplibre-compose-playground/compose/build/outputs/aar/compose-release.aar')
+```
+
+You will also need to manually specify any MapLibre dependencies now.
+For example:
+
+```groovy
+api 'org.maplibre.gl:android-sdk:10.3.1'
+api 'org.maplibre.gl:android-plugin-annotation-v9:2.0.2'
+```
+
 ### Setting an API Key for the Light and Dark Mode Demo
 
 Copy or move `api_keys_template.xml` from the root directory to `app/src/main/res/values/api_keys.xml` and add your own API key. The demo uses https://stadiamaps.com as the map style provider, but can easily be adjusted to review with another provider.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,5 +8,5 @@ plugins {
 }
 
 allprojects {
-    version = "0.0.18"
+    version = "0.0.19"
 }

--- a/compose/src/main/java/com/maplibre/compose/StaticLocationEngine.kt
+++ b/compose/src/main/java/com/maplibre/compose/StaticLocationEngine.kt
@@ -60,7 +60,7 @@ class StaticLocationEngine : LocationEngine {
       // If a timer isn't already running, create one
       callbackTimer =
           Timer().apply {
-            scheduleAtFixedRate(
+            schedule(
                 object : TimerTask() {
                   override fun run() {
                     lastLocation?.let {
@@ -87,7 +87,7 @@ class StaticLocationEngine : LocationEngine {
         // If a timer isn't already running, create one
         pendingIntentTimer =
             Timer().apply {
-              scheduleAtFixedRate(
+              schedule(
                   object : TimerTask() {
                     override fun run() {
                       lastLocation?.let {


### PR DESCRIPTION
- Replaces scheduledAtFixed rate w/ scheduled. 

There's a reasonable discussion on differences here: https://stackoverflow.com/questions/22486997/what-is-the-difference-between-schedule-and-scheduleatfixedrate.

Android studio says:

> Use of scheduleAtFixedRate is strongly discouraged because it can lead to unexpected behavior when Android processes become cached (tasks may unexpectedly execute hundreds or thousands of times in quick succession when a process changes from cached to uncached); prefer using schedule

Which I believe to have seen in ferrostar https://github.com/stadiamaps/ferrostar/pull/213.

As a result, it seems better to allow a delay in locations than unexpectedly get "hundreds or thousands" concurrent runs when this case occurs.

Happy to hear other/better ideas here as well. 