### PR TITLE
Move to maplibre 11.0.0 which removes all mapbox references

### DIFF
--- a/app/src/main/java/com/maplibre/example/examples/MapControlsExample.kt
+++ b/app/src/main/java/com/maplibre/example/examples/MapControlsExample.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import com.mapbox.mapboxsdk.geometry.LatLng
 import com.maplibre.compose.MapView
 import com.maplibre.compose.camera.MapViewCamera
 import com.maplibre.compose.rememberSaveableMapViewCamera
@@ -23,6 +22,7 @@ import com.maplibre.compose.settings.MapControls
 import com.maplibre.compose.settings.MarginInsets
 import com.maplibre.compose.symbols.Polyline
 import kotlinx.coroutines.delay
+import org.maplibre.android.geometry.LatLng
 
 /**
  * MapControls modify the UiSettings for controls on the map including the compass, logo, and

--- a/app/src/main/java/com/maplibre/example/examples/SymbolExample.kt
+++ b/app/src/main/java/com/maplibre/example/examples/SymbolExample.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_BOTTOM_RIGHT
 import com.maplibre.compose.MapView
 import com.maplibre.compose.camera.MapViewCamera
 import com.maplibre.compose.rememberSaveableMapViewCamera
@@ -18,6 +16,8 @@ import com.maplibre.compose.symbols.Symbol
 import com.maplibre.compose.symbols.builder.SymbolText
 import com.maplibre.compose.symbols.models.SymbolOffset
 import com.maplibre.example.R
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.style.layers.Property.TEXT_ANCHOR_BOTTOM_RIGHT
 
 @Composable
 fun SymbolExample() {

--- a/compose/src/main/java/com/maplibre/compose/MapView.kt
+++ b/compose/src/main/java/com/maplibre/compose/MapView.kt
@@ -9,8 +9,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.mapbox.mapboxsdk.location.engine.LocationEngine
-import com.mapbox.mapboxsdk.maps.Style
 import com.maplibre.compose.camera.MapViewCamera
 import com.maplibre.compose.ramani.LocationRequestProperties
 import com.maplibre.compose.ramani.LocationStyling
@@ -18,6 +16,8 @@ import com.maplibre.compose.ramani.MapGestureContext
 import com.maplibre.compose.ramani.MapLibre
 import com.maplibre.compose.ramani.MapLibreComposable
 import com.maplibre.compose.settings.MapControls
+import org.maplibre.android.location.engine.LocationEngine
+import org.maplibre.android.maps.Style
 
 @Composable
 fun MapView(

--- a/compose/src/main/java/com/maplibre/compose/StaticLocationEngine.kt
+++ b/compose/src/main/java/com/maplibre/compose/StaticLocationEngine.kt
@@ -6,10 +6,10 @@ import android.location.Location
 import android.location.LocationManager
 import android.os.Handler
 import android.os.Looper
-import com.mapbox.mapboxsdk.location.engine.LocationEngine
-import com.mapbox.mapboxsdk.location.engine.LocationEngineCallback
-import com.mapbox.mapboxsdk.location.engine.LocationEngineRequest
-import com.mapbox.mapboxsdk.location.engine.LocationEngineResult
+import org.maplibre.android.location.engine.LocationEngine
+import org.maplibre.android.location.engine.LocationEngineCallback
+import org.maplibre.android.location.engine.LocationEngineRequest
+import org.maplibre.android.location.engine.LocationEngineResult
 import java.lang.Exception
 import java.util.Timer
 import java.util.TimerTask

--- a/compose/src/main/java/com/maplibre/compose/camera/extensions/CameraStateToMapLibre.kt
+++ b/compose/src/main/java/com/maplibre/compose/camera/extensions/CameraStateToMapLibre.kt
@@ -1,7 +1,7 @@
 package com.maplibre.compose.camera.extensions
 
-import com.mapbox.mapboxsdk.location.modes.CameraMode
 import com.maplibre.compose.camera.CameraState
+import org.maplibre.android.location.modes.CameraMode
 
 /**
  * Converts a [CameraState] to a MapLibre [CameraMode].

--- a/compose/src/main/java/com/maplibre/compose/camera/extensions/MapViewCameraToMapLibre.kt
+++ b/compose/src/main/java/com/maplibre/compose/camera/extensions/MapViewCameraToMapLibre.kt
@@ -1,9 +1,9 @@
 package com.maplibre.compose.camera.extensions
 
-import com.mapbox.mapboxsdk.camera.CameraPosition
-import com.mapbox.mapboxsdk.geometry.LatLng
 import com.maplibre.compose.camera.CameraState
 import com.maplibre.compose.camera.MapViewCamera
+import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.geometry.LatLng
 
 /**
  * Converts a [MapViewCamera] to a MapLibre [CameraPosition].

--- a/compose/src/main/java/com/maplibre/compose/ramani/CoordToPixelMapper.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/CoordToPixelMapper.kt
@@ -13,7 +13,7 @@ package com.maplibre.compose.ramani
 import android.graphics.PointF
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @Composable
 fun CoordToPixelMapper(coordinates: MutableList<LatLng>, onChange: (List<PointF>) -> Unit) {

--- a/compose/src/main/java/com/maplibre/compose/ramani/DistanceBetweenCoords.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/DistanceBetweenCoords.kt
@@ -13,7 +13,7 @@ package com.maplibre.compose.ramani
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
 import androidx.core.graphics.minus
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @MapLibreComposable
 @Composable

--- a/compose/src/main/java/com/maplibre/compose/ramani/LocationRequestProperties.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/LocationRequestProperties.kt
@@ -10,12 +10,12 @@
 package com.maplibre.compose.ramani
 
 import android.os.Parcelable
-import com.mapbox.mapboxsdk.location.engine.LocationEngineRequest
 import com.maplibre.compose.ramani.LocationPriority.PRIORITY_BALANCED_POWER_ACCURACY
 import com.maplibre.compose.ramani.LocationPriority.PRIORITY_HIGH_ACCURACY
 import com.maplibre.compose.ramani.LocationPriority.PRIORITY_LOW_POWER
 import com.maplibre.compose.ramani.LocationPriority.PRIORITY_NO_POWER
 import kotlinx.parcelize.Parcelize
+import org.maplibre.android.location.engine.LocationEngineRequest
 
 /**
  * @property PRIORITY_HIGH_ACCURACY Request the most accurate location.

--- a/compose/src/main/java/com/maplibre/compose/ramani/MapCameraUpdater.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/MapCameraUpdater.kt
@@ -4,11 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
-import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener
-import com.mapbox.mapboxsdk.location.modes.CameraMode
-import com.mapbox.mapboxsdk.location.modes.RenderMode
-import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.maplibre.compose.camera.CameraState
 import com.maplibre.compose.camera.MapViewCamera
 import com.maplibre.compose.camera.MapViewCameraDefaults
@@ -20,6 +15,11 @@ import com.maplibre.compose.camera.extensions.toMapLibre
 import com.maplibre.compose.camera.models.CameraMotion
 import com.maplibre.compose.camera.models.CameraPadding
 import com.maplibre.compose.camera.models.CameraPitchRange
+import org.maplibre.android.camera.CameraUpdateFactory
+import org.maplibre.android.location.OnLocationCameraTransitionListener
+import org.maplibre.android.location.modes.CameraMode
+import org.maplibre.android.location.modes.RenderMode
+import org.maplibre.android.maps.MapLibreMap
 
 @Composable
 internal fun MapCameraUpdater(camera: MutableState<MapViewCamera>) {
@@ -79,7 +79,7 @@ internal fun MapCameraUpdater(camera: MutableState<MapViewCamera>) {
 }
 
 private class CameraTransitionListener(
-    val map: MapboxMap,
+    val map: MapLibreMap,
     val zoom: Double?,
     val tilt: Double?,
     val padding: DoubleArray?
@@ -108,14 +108,14 @@ private class CameraTransitionListener(
   }
 }
 
-private class MapPropertiesNode(val map: MapboxMap, var camera: MutableState<MapViewCamera>) :
+private class MapPropertiesNode(val map: MapLibreMap, var camera: MutableState<MapViewCamera>) :
     MapNode {
   override fun onAttached() {
     cameraUpdate(map, camera.value)
   }
 }
 
-private fun cameraUpdate(map: MapboxMap, camera: MapViewCamera) {
+private fun cameraUpdate(map: MapLibreMap, camera: MapViewCamera) {
   val cameraUpdate = CameraUpdateFactory.newCameraPosition(camera.toCameraPosition())
 
   val newPadding = camera.padding.toDoubleArray()

--- a/compose/src/main/java/com/maplibre/compose/ramani/MapLibre.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/MapLibre.kt
@@ -25,14 +25,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
-import com.mapbox.mapboxsdk.location.engine.LocationEngine
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.mapboxsdk.style.layers.Layer
-import com.mapbox.mapboxsdk.style.sources.Source
-import com.mapbox.mapboxsdk.utils.BitmapUtils
 import com.maplibre.compose.camera.MapViewCamera
 import com.maplibre.compose.settings.MapControls
+import org.maplibre.android.location.engine.LocationEngine
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.Style
+import org.maplibre.android.style.layers.Layer
+import org.maplibre.android.style.sources.Source
+import org.maplibre.android.utils.BitmapUtils
 import setupLocation
 
 @Retention(AnnotationRetention.BINARY)
@@ -145,7 +145,7 @@ internal fun MapLibre(
       }
 }
 
-private fun MapboxMap.applyMapControls(mapControls: MapControls) {
+private fun MapLibreMap.applyMapControls(mapControls: MapControls) {
   mapControls.attribution?.let { newAttribution ->
     newAttribution.enabled?.let { this.uiSettings.isAttributionEnabled = it }
     newAttribution.gravity?.let { this.uiSettings.attributionGravity = it }
@@ -171,12 +171,12 @@ private fun MapboxMap.applyMapControls(mapControls: MapControls) {
   }
 }
 
-private fun MapboxMap.applyProperties(properties: MapProperties) {
+private fun MapLibreMap.applyProperties(properties: MapProperties) {
   properties.maxZoom?.let { this.setMaxZoomPreference(it) }
   // TODO: Add Dynamic camera pitch binding
 }
 
-private fun MapboxMap.addImages(context: Context, images: List<Pair<String, Int>>?) {
+private fun MapLibreMap.addImages(context: Context, images: List<Pair<String, Int>>?) {
   images?.let {
     images
         .mapNotNull { image ->
@@ -188,10 +188,10 @@ private fun MapboxMap.addImages(context: Context, images: List<Pair<String, Int>
   }
 }
 
-private fun MapboxMap.addSources(sources: List<Source>?) {
+private fun MapLibreMap.addSources(sources: List<Source>?) {
   sources?.let { sources.forEach { style!!.addSource(it) } }
 }
 
-private fun MapboxMap.addLayers(layers: List<Layer>?) {
+private fun MapLibreMap.addLayers(layers: List<Layer>?) {
   layers?.let { layers.forEach { style!!.addLayer(it) } }
 }

--- a/compose/src/main/java/com/maplibre/compose/ramani/MapLibreCallbacks.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/MapLibreCallbacks.kt
@@ -2,8 +2,8 @@ package com.maplibre.compose.ramani
 
 import android.graphics.PointF
 import android.util.Log
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.maps.MapboxMap
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
 
 enum class MapGestureType {
   TAP,
@@ -30,7 +30,7 @@ data class MapGestureContext(
  * @param onTapGestureCallback The callback for a tap gesture.
  * @param onLongPressGestureCallback The callback for a long press gesture.
  */
-internal fun MapboxMap.setupEventCallbacks(
+internal fun MapLibreMap.setupEventCallbacks(
     onTapGestureCallback: ((MapGestureContext) -> Unit)? = null,
     onLongPressGestureCallback: ((MapGestureContext) -> Unit)? = null,
 ) {

--- a/compose/src/main/java/com/maplibre/compose/ramani/MapLibreCompose.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/MapLibreCompose.kt
@@ -17,30 +17,27 @@ import androidx.compose.runtime.CompositionContext
 import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.android.gestures.RotateGestureDetector
 import com.mapbox.android.gestures.StandardScaleGestureDetector
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnMoveListener
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnRotateListener
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnScaleListener
-import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.mapboxsdk.plugins.annotation.AnnotationManager
-import com.mapbox.mapboxsdk.plugins.annotation.Circle
-import com.mapbox.mapboxsdk.plugins.annotation.CircleManager
-import com.mapbox.mapboxsdk.plugins.annotation.Fill
-import com.mapbox.mapboxsdk.plugins.annotation.FillManager
-import com.mapbox.mapboxsdk.plugins.annotation.Line
-import com.mapbox.mapboxsdk.plugins.annotation.LineManager
-import com.mapbox.mapboxsdk.plugins.annotation.OnCircleClickListener
-import com.mapbox.mapboxsdk.plugins.annotation.OnCircleDragListener
-import com.mapbox.mapboxsdk.plugins.annotation.OnCircleLongClickListener
-import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolClickListener
-import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolLongClickListener
-import com.mapbox.mapboxsdk.plugins.annotation.Symbol
-import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlin.math.abs
 import kotlinx.coroutines.awaitCancellation
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
+import org.maplibre.android.plugins.annotation.AnnotationManager
+import org.maplibre.android.plugins.annotation.Circle
+import org.maplibre.android.plugins.annotation.CircleManager
+import org.maplibre.android.plugins.annotation.Fill
+import org.maplibre.android.plugins.annotation.FillManager
+import org.maplibre.android.plugins.annotation.Line
+import org.maplibre.android.plugins.annotation.LineManager
+import org.maplibre.android.plugins.annotation.OnCircleClickListener
+import org.maplibre.android.plugins.annotation.OnCircleDragListener
+import org.maplibre.android.plugins.annotation.OnCircleLongClickListener
+import org.maplibre.android.plugins.annotation.OnSymbolClickListener
+import org.maplibre.android.plugins.annotation.OnSymbolLongClickListener
+import org.maplibre.android.plugins.annotation.Symbol
+import org.maplibre.android.plugins.annotation.SymbolManager
 
 internal suspend inline fun disposingComposition(factory: () -> Composition) {
   val composition = factory()
@@ -60,7 +57,7 @@ internal suspend fun MapView.newComposition(
   return Composition(MapApplier(map, this, style), parent).apply { setContent(content) }
 }
 
-internal suspend fun MapboxMap.awaitStyle(styleUrl: String) = suspendCoroutine { continuation ->
+internal suspend fun MapLibreMap.awaitStyle(styleUrl: String) = suspendCoroutine { continuation ->
   setStyle(styleUrl) { style -> continuation.resume(style) }
 }
 
@@ -74,7 +71,7 @@ internal interface MapNode {
 
 private object MapNodeRoot : MapNode
 
-internal class MapApplier(val map: MapboxMap, val mapView: MapView, val style: Style) :
+internal class MapApplier(val map: MapLibreMap, val mapView: MapView, val style: Style) :
     AbstractApplier<MapNode>(MapNodeRoot) {
   private val decorations = mutableListOf<MapNode>()
 
@@ -92,7 +89,7 @@ internal class MapApplier(val map: MapboxMap, val mapView: MapView, val style: S
 
   private fun attachMapListeners() {
     map.addOnScaleListener(
-        object : OnScaleListener {
+        object : MapLibreMap.OnScaleListener {
           override fun onScaleBegin(detector: StandardScaleGestureDetector) {
             decorations.filterIsInstance<MapObserverNode>().forEach { it.onMapScaled() }
           }
@@ -105,7 +102,7 @@ internal class MapApplier(val map: MapboxMap, val mapView: MapView, val style: S
         })
 
     map.addOnMoveListener(
-        object : OnMoveListener {
+        object : MapLibreMap.OnMoveListener {
           override fun onMoveBegin(detector: MoveGestureDetector) {
             decorations.filterIsInstance<MapObserverNode>().forEach { it.onMapMoved() }
           }
@@ -118,7 +115,7 @@ internal class MapApplier(val map: MapboxMap, val mapView: MapView, val style: S
         })
 
     map.addOnRotateListener(
-        object : OnRotateListener {
+        object : MapLibreMap.OnRotateListener {
           override fun onRotateBegin(detector: RotateGestureDetector) {
             decorations.filterIsInstance<MapObserverNode>().forEach {
               it.onMapRotated(map.cameraPosition.bearing)

--- a/compose/src/main/java/com/maplibre/compose/ramani/MapLibreLocation.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/MapLibreLocation.kt
@@ -5,19 +5,19 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.util.Log
 import androidx.compose.runtime.MutableState
-import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
-import com.mapbox.mapboxsdk.location.LocationComponentOptions
-import com.mapbox.mapboxsdk.location.engine.LocationEngine
-import com.mapbox.mapboxsdk.location.engine.LocationEngineCallback
-import com.mapbox.mapboxsdk.location.engine.LocationEngineDefault
-import com.mapbox.mapboxsdk.location.engine.LocationEngineRequest
-import com.mapbox.mapboxsdk.location.engine.LocationEngineResult
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.Style
 import com.maplibre.compose.ramani.LocationRequestProperties
 import com.maplibre.compose.ramani.LocationStyling
+import org.maplibre.android.location.LocationComponentActivationOptions
+import org.maplibre.android.location.LocationComponentOptions
+import org.maplibre.android.location.engine.LocationEngine
+import org.maplibre.android.location.engine.LocationEngineCallback
+import org.maplibre.android.location.engine.LocationEngineDefault
+import org.maplibre.android.location.engine.LocationEngineRequest
+import org.maplibre.android.location.engine.LocationEngineResult
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.Style
 
-internal fun MapboxMap.setupLocation(
+internal fun MapLibreMap.setupLocation(
     context: Context,
     style: Style,
     locationEngine: LocationEngine?,

--- a/compose/src/main/java/com/maplibre/compose/ramani/MapProperties.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/MapProperties.kt
@@ -11,14 +11,14 @@ package com.maplibre.compose.ramani
 
 import android.os.Parcelable
 import androidx.annotation.FloatRange
-import com.mapbox.mapboxsdk.constants.MapboxConstants
 import kotlinx.parcelize.Parcelize
+import org.maplibre.android.constants.MapLibreConstants
 
 @Parcelize
 class MapProperties(
     @FloatRange(
-        from = MapboxConstants.MINIMUM_ZOOM.toDouble(),
-        to = MapboxConstants.MAXIMUM_ZOOM.toDouble())
+        from = MapLibreConstants.MINIMUM_ZOOM.toDouble(),
+        to = MapLibreConstants.MAXIMUM_ZOOM.toDouble())
     var maxZoom: Double? = null,
 ) : Parcelable {
   constructor(mapProperties: MapProperties) : this(mapProperties.maxZoom)

--- a/compose/src/main/java/com/maplibre/compose/ramani/PixelToCoordMapper.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/PixelToCoordMapper.kt
@@ -13,7 +13,7 @@ package com.maplibre.compose.ramani
 import android.graphics.PointF
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @Composable
 fun PixelToCoordMapper(points: List<PointF>, onChange: (List<LatLng>) -> Unit) {

--- a/compose/src/main/java/com/maplibre/compose/ramani/Utils.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/Utils.kt
@@ -18,16 +18,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
+import org.maplibre.android.MapLibre
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 @Composable
 fun rememberMapViewWithLifecycle(): MapView {
   val context = LocalContext.current
-  Mapbox.getInstance(context)
+  MapLibre.getInstance(context)
   val mapView = remember { MapView(context) }
   val lifecycle = LocalLifecycleOwner.current.lifecycle
 
@@ -54,6 +54,6 @@ fun getMapLifecycleObserver(mapView: MapView): LifecycleEventObserver {
   }
 }
 
-suspend inline fun MapView.awaitMap(): MapboxMap = suspendCoroutine { continuation ->
+suspend inline fun MapView.awaitMap(): MapLibreMap = suspendCoroutine { continuation ->
   getMapAsync { continuation.resume(it) }
 }

--- a/compose/src/main/java/com/maplibre/compose/ramani/VertexInsertCalculator.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/VertexInsertCalculator.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
 import androidx.core.graphics.minus
 import androidx.core.graphics.plus
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @MapLibreComposable
 @Composable

--- a/compose/src/main/java/com/maplibre/compose/symbols/Circle.kt
+++ b/compose/src/main/java/com/maplibre/compose/symbols/Circle.kt
@@ -13,11 +13,11 @@ package com.maplibre.compose.symbols
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.plugins.annotation.CircleOptions
 import com.maplibre.compose.ramani.CircleNode
 import com.maplibre.compose.ramani.MapApplier
 import com.maplibre.compose.ramani.MapLibreComposable
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.CircleOptions
 
 @Composable
 @MapLibreComposable

--- a/compose/src/main/java/com/maplibre/compose/symbols/CircleWithItem.kt
+++ b/compose/src/main/java/com/maplibre/compose/symbols/CircleWithItem.kt
@@ -13,10 +13,10 @@ package com.maplibre.compose.symbols
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.style.layers.Property.ICON_ANCHOR_CENTER
 import com.maplibre.compose.symbols.builder.SymbolText
 import com.maplibre.compose.symbols.models.SymbolOffset
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.style.layers.Property.ICON_ANCHOR_CENTER
 
 @Composable
 fun UpdateCenter(coord: LatLng, centerUpdated: (LatLng) -> Unit) {

--- a/compose/src/main/java/com/maplibre/compose/symbols/Fill.kt
+++ b/compose/src/main/java/com/maplibre/compose/symbols/Fill.kt
@@ -13,11 +13,11 @@ package com.maplibre.compose.symbols
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.plugins.annotation.FillOptions
 import com.maplibre.compose.ramani.FillNode
 import com.maplibre.compose.ramani.MapApplier
 import com.maplibre.compose.ramani.MapLibreComposable
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.FillOptions
 
 @Composable
 @MapLibreComposable

--- a/compose/src/main/java/com/maplibre/compose/symbols/Polygon.kt
+++ b/compose/src/main/java/com/maplibre/compose/symbols/Polygon.kt
@@ -17,9 +17,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.core.graphics.minus
 import androidx.core.graphics.plus
-import com.mapbox.mapboxsdk.geometry.LatLng
 import com.maplibre.compose.ramani.MapApplier
 import com.maplibre.compose.ramani.MapLibreComposable
+import org.maplibre.android.geometry.LatLng
 import kotlin.math.atan2
 
 @Composable

--- a/compose/src/main/java/com/maplibre/compose/symbols/Polyline.kt
+++ b/compose/src/main/java/com/maplibre/compose/symbols/Polyline.kt
@@ -13,12 +13,12 @@ package com.maplibre.compose.symbols
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.plugins.annotation.LineOptions
-import com.mapbox.mapboxsdk.style.layers.Property
 import com.maplibre.compose.ramani.MapApplier
 import com.maplibre.compose.ramani.MapLibreComposable
 import com.maplibre.compose.ramani.PolyLineNode
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.LineOptions
+import org.maplibre.android.style.layers.Property
 
 @Composable
 @MapLibreComposable

--- a/compose/src/main/java/com/maplibre/compose/symbols/Symbol.kt
+++ b/compose/src/main/java/com/maplibre/compose/symbols/Symbol.kt
@@ -18,15 +18,15 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.imageResource
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions
-import com.mapbox.mapboxsdk.style.layers.Property.ICON_ANCHOR_CENTER
 import com.maplibre.compose.ramani.MapApplier
 import com.maplibre.compose.ramani.MapLibreComposable
 import com.maplibre.compose.ramani.SymbolNode
 import com.maplibre.compose.symbols.builder.SymbolText
 import com.maplibre.compose.symbols.models.SymbolOffset
 import com.maplibre.compose.symbols.models.toMaplibreOffset
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.SymbolOptions
+import org.maplibre.android.style.layers.Property.ICON_ANCHOR_CENTER
 
 @Composable
 @MapLibreComposable

--- a/compose/src/main/java/com/maplibre/compose/symbols/builder/SymbolText.kt
+++ b/compose/src/main/java/com/maplibre/compose/symbols/builder/SymbolText.kt
@@ -1,8 +1,8 @@
 package com.maplibre.compose.symbols.builder
 
-import com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_CENTER
-import com.mapbox.mapboxsdk.style.layers.Property.TEXT_JUSTIFY_AUTO
 import com.maplibre.compose.symbols.models.SymbolOffset
+import org.maplibre.android.style.layers.Property.TEXT_ANCHOR_CENTER
+import org.maplibre.android.style.layers.Property.TEXT_JUSTIFY_AUTO
 
 data class SymbolText(
     var text: String,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.0"
+agp = "8.5.2"
 kotlin = "1.9.24"
 ktfmt = "0.19.0"
 mavenPublish = "0.29.0"
@@ -7,12 +7,12 @@ coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.3"
-activityCompose = "1.9.0"
-composeBom = "2024.06.00"
-maplibre = "10.3.1"
-maplibre-annotation = "2.0.2"
-navigationCompose = "2.7.7"
+lifecycleRuntimeKtx = "2.8.5"
+activityCompose = "1.9.2"
+composeBom = "2024.09.01"
+maplibre = "11.0.0"
+maplibre-annotation = "3.0.0"
+navigationCompose = "2.8.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
Change all imports and rename all places where Mapbox is used to MapLibre.

This is 'speculative' in that I obviously haven't discussed it with anyone, but I assume that it'll have to happen at some point, and I made the changes locally, so here you are! 