### PR TITLE
Show the initial location immediately; upgrade deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,5 +9,5 @@ plugins {
 }
 
 allprojects {
-    version = "0.2.3"
+    version = "0.2.2"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,5 +9,5 @@ plugins {
 }
 
 allprojects {
-    version = "0.2.2"
+    version = "0.2.3"
 }

--- a/compose/src/main/java/com/maplibre/compose/ramani/MapLibre.kt
+++ b/compose/src/main/java/com/maplibre/compose/ramani/MapLibre.kt
@@ -33,6 +33,7 @@ import com.mapbox.mapboxsdk.style.layers.Layer
 import com.mapbox.mapboxsdk.style.sources.Source
 import com.mapbox.mapboxsdk.utils.BitmapUtils
 import com.maplibre.compose.camera.MapViewCamera
+import com.maplibre.compose.camera.extensions.toCameraPosition
 import com.maplibre.compose.rememberSaveableMapControls
 import com.maplibre.compose.runtime.nodes.MapCameraNode
 import com.maplibre.compose.runtime.nodes.MapControlsNode
@@ -129,6 +130,7 @@ internal fun MapLibre(
       maplibreMap.addImages(context, currentImages)
       maplibreMap.addSources(currentSources)
       maplibreMap.addLayers(currentLayers)
+      maplibreMap.cameraPosition = camera.value.toCameraPosition()
 
       // Notify the parent callback that the map is ready with a style.
       // This must include all style modifications from adding images, sources, and layers.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,11 +8,11 @@ junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.6"
-activityCompose = "1.9.2"
-composeBom = "2024.09.02"
+activityCompose = "1.9.3"
+composeBom = "2024.10.00"
 maplibre = "10.3.1" # 11.0.0 is currently blocked by a crash - need to re-test in the near future.
 maplibre-annotation = "2.0.2"
-navigationCompose = "2.8.1"
+navigationCompose = "2.8.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
This fixes a bug that I noticed in the Ferrostar demo app which will show up basically everywhere. On Android, we don't directly set the initial camera position, and just wait for it to animate later. This results in a painfully weird animation.

As far as I can tell, this seems to fix the issue. Tested with a local release build + the Ferrostar Android demo app.