### PR TITLE
Support switching Vulkan during build time

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.accessors.dm.LibrariesForLibs
 
 plugins {
     alias(libs.plugins.androidLibrary)
@@ -71,6 +72,23 @@ dependencies {
 
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+}
+
+val useVulkan = project.hasProperty("useVulkan")
+if (useVulkan) {
+    val libs = the<LibrariesForLibs>()
+    val maplibreVulkan = libs.maplibre.vulkan
+
+    project.afterEvaluate {
+        this.configurations.configureEach {
+            resolutionStrategy {
+                dependencySubstitution {
+                    substitute(module("org.maplibre.gl:android-sdk"))
+                        .using(module(maplibreVulkan.get().toString()))
+                }
+            }
+        }
+    }
 }
 
 mavenPublishing {

--- a/compose/src/main/java/com/maplibre/compose/symbols/builder/SymbolText.kt
+++ b/compose/src/main/java/com/maplibre/compose/symbols/builder/SymbolText.kt
@@ -1,8 +1,8 @@
 package com.maplibre.compose.symbols.builder
 
-import com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_CENTER
-import com.mapbox.mapboxsdk.style.layers.Property.TEXT_JUSTIFY_AUTO
 import com.maplibre.compose.symbols.models.SymbolOffset
+import org.maplibre.android.style.layers.Property.TEXT_ANCHOR_CENTER
+import org.maplibre.android.style.layers.Property.TEXT_JUSTIFY_AUTO
 
 data class SymbolText(
     var text: String,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2024.10.01"
-maplibre = "11.6.1"
+maplibre = "11.7.1"
 maplibre-annotation = "3.0.2"
 navigationCompose = "2.8.3"
 mockk = "1.13.13"
@@ -33,6 +33,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 maplibre = { group = "org.maplibre.gl", name = "android-sdk", version.ref = "maplibre" }
+maplibre-vulkan = { module = "org.maplibre.gl:android-sdk-vulkan", version.ref = "maplibre" }
 maplibre-annotation = { group = "org.maplibre.gl", name = "android-plugin-annotation-v9", version.ref = "maplibre-annotation"}
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 


### PR DESCRIPTION
Passing a -PuseVulkan will swap the MapLibre dependency for the Vulkan
variant.